### PR TITLE
Fix pypy checks not actually running the tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-20.04, windows-2019, macOS-10.15]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = True
-envlist = py37, py38, py39, py310
+envlist = py37, py38, py39, py310, pypy37, pypy38, pypy39
 
 [gh-actions]
 python =
@@ -8,6 +8,9 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    pypy-3.7: pypy37
+    pypy-3.8: pypy38
+    pypy-3.9: pypy39
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
Tox was doing nothing on pypy tests because it wasn't configured to run with pypy.